### PR TITLE
Fix typos in Den quickstart

### DIFF
--- a/docs/quick-start-den.ipynb
+++ b/docs/quick-start-den.ipynb
@@ -13,7 +13,27 @@
    "id": "ecfd8022-1ee4-4755-bbb7-98b45f5dd04c",
    "metadata": {},
    "source": [
-    "[Runhouse Den](https://www.run.house/dashboard) lets you manage and track your infra, services, and resources (clusters, functions, secrets, etc). These resources can be easily reloaded from any environment, and ready to be used without additional setup, or even shared with another user or teammate. Then, in the Web UI, access, visualize, and manage your resources, along with version history. "
+    "[Runhouse Den](https://www.run.house/dashboard) lets you manage and track your infra, services, and resources (clusters, functions, secrets, etc). These resources can be easily reloaded from any environment, are ready to be used without additional setup, and can even be shared with another user or teammate. Then, in the Den Web UI, you can access, visualize, and manage your resources along with version history. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c2edfb7",
+   "metadata": {},
+   "source": [
+    "## Installing Runhouse\n",
+    "\n",
+    "To use Runhouse to launch on-demand clusters, run the following installation command. This includes [SkyPilot](https://github.com/skypilot-org/skypilot), which is used for launching fresh VMs through various cloud providers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32ea6e83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install \"runhouse[sky]\""
    ]
   },
   {
@@ -23,14 +43,14 @@
    "source": [
     "## Account Creation & Login\n",
     "\n",
-    "You can create an account on the [run.house](https://www.run.house) website, or by calling the login command in Python or CLI.\n",
+    "You can create an account on the [run.house](https://www.run.house) website or by calling the login command in Python or CLI.\n",
     "\n",
     "To login on your dev environment, call ``rh.login()`` in Python or ``runhouse login`` in CLI."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "09cb7d93-d67b-497b-840d-e52cbf11c992",
    "metadata": {},
    "outputs": [],
@@ -69,53 +89,15 @@
    "id": "7ec1cf1a-808c-4f5b-915f-1f34fe913141",
    "metadata": {},
    "source": [
-    "Let's start by constructing some runhouse resources that we'd like to save down. These resources were first defined in our [Cloud Quick Start Tutorial](https://www.run.house/docs/tutorials/quick-start-cloud)."
+    "Let's start by constructing some runhouse resources that we'd like to save down. These resources were first defined in our [Cloud Quick Start Tutorial](https://www.run.house/docs/tutorials/quick-start-cloud). As a reminder, you may need to confirm that your cloud credentials are properly configured by running `sky check`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "a2eda1a7-f07f-4f12-bef1-58a2b954cf50",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "cluster = rh.ondemand_cluster(\n",
     "    name=\"rh-cluster\",\n",
@@ -158,7 +140,7 @@
    "id": "152bb53e-36c9-4205-bc6d-8630e57abd71",
    "metadata": {},
    "source": [
-    "You can save the resources we created above with:"
+    "You can save the resources we created above to your Den account with the `save` method:"
    ]
   },
   {
@@ -187,14 +169,30 @@
    "id": "26264682-b68b-4a0f-a12f-6f0daf746330",
    "metadata": {},
    "source": [
-    "```\n",
-    "\"\"\"\n",
+    "```python\n",
     "import runhouse as rh\n",
     "\n",
     "if __name__ == \"__main__\":\n",
     "    reloaded_fn = rh.function(name=\"get_platform\")\n",
     "    print(reloaded_fn())\n",
-    "\"\"\"\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64c1256f",
+   "metadata": {},
+   "source": [
+    "The `name` used to reload the function is the method name by default. You can customize a function name using the following syntax:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61c90fc4",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "remote_get_platform = rh.function(fn=get_platform, name=\"my_function\").to(cluster)\n",
     "```"
    ]
   },
@@ -221,7 +219,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "remote_fn.share(\n",
+    "remote_get_platform.share(\n",
     "    users=[\"teammate1@email.com\"],\n",
     "    access_level=\"write\",\n",
     ")"
@@ -234,7 +232,7 @@
    "source": [
     "## Web UI\n",
     "\n",
-    "After saving your resources, you can log in and see them on your [Den dashboard](https://www.run.house/dashboard), labeled as `<username>/rh-cluster` and `<username>/get_platform`. \n",
+    "After saving your resources, you can log in and see them on your [Den dashboard](https://www.run.house/dashboard), labeled as `/<username>/rh-cluster` and `/<username>/get_platform`. \n",
     "\n",
     "Clicking into the resource provides information about your resource. You can view the resource metadata, previous versions, and activity, or add a description to the resource."
    ]
@@ -251,14 +249,6 @@
     "* Resource Management https://www.run.house/docs/tutorials/api-resources\n",
     "* Secrets Management https://www.run.house/docs/tutorials/api-secrets\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "369c832d-57ac-4fab-addd-e4deb5496faf",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Starting out wanting to remove some weird outputs that were showing up in /docs but also ended up:
- Clarifying some of the copy and some grammar catches
- Including the installation section so this is standalone and not dependent on the other Quickstarts
- Added a section about naming (was confused how that worked originally when I was walking through the guide)